### PR TITLE
chore: fix path

### DIFF
--- a/source/jobs/pre-requisitos.md
+++ b/source/jobs/pre-requisitos.md
@@ -10,7 +10,7 @@ extends: _layouts.job
 * Conhecer e aceitar os termos de nosso [Estatuto](https://gitlab.com/librecodecoop/estatuto) e [Regimento Interno](https://gitlab.com/librecodecoop/regimento-interno)
 * Atuar na atividade fim da cooperativa
 * Não atuar como sócio em empresa na atividade fim da LibreCode
-* Dar uma olhada nos [materiais de apoio](../materiais-de-apoio)
+* Dar uma olhada nos [materiais de apoio](materiais-de-apoio)
 * Estar de acordo com nossa
   * Missão
     > Colaborar para a construção de uma economia solidária por meio do cooperativismo, democratizando a tecnologia da informação, a segurança e a privacidade de dados com software livre.


### PR DESCRIPTION
The file materiais-de-apoio stay at the same folder