### PR TITLE
fix: env name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .docker/php
     ports:
-      - "127.0.0.1:${HTTP_PORT:-3000}:3000"
+      - "127.0.0.1:${HTTP_PORT_PHP:-3000}:3000"
       - "127.0.0.1:${HTTP_PORT_BROWSERSYNC:-3001}:3001"
     volumes:
       - .:/var/www/html


### PR DESCRIPTION
prevent to use the same env port number name into more than one service.