### PR TITLE
Create funding.json for LibreCode and LibreSign

### DIFF
--- a/source/.well-known/funding-manifest-urls
+++ b/source/.well-known/funding-manifest-urls
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/LibreSign/libresign/refs/heads/main/funding.json
+https://librecode.coop/funding.json

--- a/source/funding.json
+++ b/source/funding.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://fundingjson.org/schema/v1.1.0.json",
+  "version": "v1.1.0",
+
+  "entity": {
+    "type": "organisation",
+    "role": "owner",
+    "name": "LibreCode Cooperativa",
+    "email": "contact@librecode.coop",
+    "phone": "+552120422073",
+    "description": "LibreCode is a cooperative founded by software developers and technology professionals with the vision of making open-source solutions more accessible while highlighting their value in fostering innovation, security, and technological freedom without borders.\n\nBeyond our cooperative principles, we are committed to providing open-source software and professional support so that the entire community can benefit from what we build. For more than seven years, we have been creating and maintaining open-source solutions while helping more people discover and adopt free and open-source software.",
+    "webpageUrl": {
+      "url": "https://librecode.coop",
+      "wellKnown": "https://librecode.coop/.well-known/funding-manifest-urls"
+    }
+  },
+
+  "projects": [
+    {
+      "guid": "libresign",
+      "name": "LibreSign",
+      "description": "LibreSign was developed by LibreCode, accumulating over 100,000 downloads across multiple countries. In 2025, it was recognized as a Digital Public Good.\n\nLibreSign is a digital signature platform with legal validity, designed for both individuals and organizations. It provides an API for ERP integrations and supports complete end-to-end implementation.\n\nThe platform is already used by municipalities to sign documents within their own systems. It also integrates with WhatsApp and other communication channels to simplify and accelerate signature collection.\n\nLibreSign supports multiple authentication methods, providing greater security throughout the signing process, and receives continuous improvements and updates.",
+      "webpageUrl": {
+        "url": "https://libresign.coop",
+        "wellKnown": "https://libresign.coop/.well-known/funding-manifest-urls"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/LibreSign/libresign"
+      },
+      "licenses": [
+        "spdx:AGPL-3.0"
+      ],
+      "tags": [
+        "digital-signature",
+        "document-management",
+        "digital-public-good",
+        "cooperativism",
+        "open-source-software"
+      ]
+    }
+  ],
+
+  "funding": {
+    "channels": [
+      {
+        "guid": "github-sponsors",
+        "type": "payment-provider",
+        "address": "https://github.com/sponsors/LibreSign",
+        "description": "Recurring or one-time contributions through GitHub Sponsors."
+      }
+    ],
+
+    "plans": [
+      {
+        "guid": "developer-time-yearly",
+        "status": "active",
+        "name": "Annual support for the development team",
+        "description": "This contribution covers part of the costs associated with maintaining and expanding our development team and infrastructure, enabling us to continue improving LibreSign and delivering future releases.",
+        "amount": 75000,
+        "currency": "USD",
+        "frequency": "yearly",
+        "channels": ["github-sponsors"]
+      },
+      {
+        "guid": "developer-time-monthly",
+        "status": "active",
+        "name": "full-time sustainable development and maintenance by the team",
+        "description": "This contribution covers part of the costs associated with maintaining and expanding our development team and infrastructure, enabling us to continue improving LibreSign and delivering future releases.",
+        "amount": 6250,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": ["github-sponsors"]
+            }
+    ]
+  }
+}  


### PR DESCRIPTION
Added funding.json to define funding schema and details for LibreCode and its project LibreSign, including funding channels and plans.