### PR TITLE
Fix: OpenGraph default logo and job page image 

### DIFF
--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -19,14 +19,14 @@
   @if (!empty($og_image))
     <meta property="og:image" content="{{ $og_image }}"/>
   @else
-    <meta property="og:image" content="{{ $page->baseUrl }}assets/images/logo.png"/>
+    <meta property="og:image" content="{{ $page->baseUrl }}assets/images/logo/librecode.png"/>
   @endif
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{{ $page->title ?? 'LibreCode' }}">
   <meta name="twitter:description" content="{{ $page->description ?? 'Cooperativa de tecnologia especializada em soluções corporativas com software livre.' }}">
-  <meta name="twitter:image" content="{{ $page->baseUrl }}assets/images/logo.png">
+  <meta name="twitter:image" content="{{ $page->baseUrl }}assets/images/logo/librecode.png">
 
   <!-- Schema.org JSON-LD -->
   <script type="application/ld+json">

--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -14,6 +14,7 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ $page->getUrl() }}">
+  <meta property="og:site_name" content="LibreCode">
   <meta property="og:title" content="{{ $page->title ?? 'LibreCode — Cooperativa de Software Livre' }}">
   <meta property="og:description" content="{{ $page->description ?? 'Cooperativa de tecnologia especializada em soluções corporativas com software livre. Nuvem privada, gestão, CRM, atendimento e automação com hospedagem no Brasil.' }}">
   @if (!empty($og_image))

--- a/source/jobs/index.blade.php
+++ b/source/jobs/index.blade.php
@@ -3,7 +3,7 @@ title: Coopere com a LibreCode — Faça parte da cooperativa
 description: Junte-se a uma cooperativa de desenvolvedores de software livre. Sem chefes, com cooperados. Conheça os benefícios, as áreas de atuação e como fazer parte da LibreCode.
 ---
 
-@extends('_layouts.main')
+@extends('_layouts.main', ['og_image' => "/assets/images/librecode_team.jpeg"])
 @section('body')
 
 {{-- ==========================  HERO  ========================== --}}


### PR DESCRIPTION
This PR resolves #228. Most of the discussion is on the referenced issue, but to sum it up:

- Fixes default logo referencing address on main.blade.php
- Sets og image on job page to team photo as similar projects do (see attached reference images)
 
Extra
- Adds recommended og site_name meta tag (i.e. Discord needs it to properly show the card, without it it seems anonymous)

Extra extra:
Facebook's [Open Graph Requirements documentation](https://developers.facebook.com/documentation/sharing/webmasters/images#requirements) recommends the image to be 1200 x 630 and at least 600 x 315 pixels. The current available image is 552 x 316, which is smaller than the minimum size. I will open an issue requesting for a 1200 x 630 to be added, and I can follow up to update the default.

### Reference
<img width="438" height="350" alt="image" src="https://github.com/user-attachments/assets/7b467d8f-9b44-4db5-9018-2ae2eee6f995" />
<img width="445" height="352" alt="image" src="https://github.com/user-attachments/assets/0bdf469e-0e74-45b9-b4d5-7e928425f2b3" />
<img width="425" height="364" alt="image" src="https://github.com/user-attachments/assets/eaf7c821-75ca-450a-9c14-f3f4ad06b3bc" />

