### PR TITLE
feat: use registry to build image

### DIFF
--- a/.github/workflows/docker-php.yml
+++ b/.github/workflows/docker-php.yml
@@ -1,0 +1,98 @@
+name: Docker PHP Publish
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  push_to_registry:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/librecodecoop/site-php
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        id: docker-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: php-buildx-${{ github.sha }}
+          restore-keys: |
+            php-buildx-
+
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Set Dockerfile path
+        id: dockerfile
+        run: |
+          DOCKERFILE=$([[ -f ".docker/php/Dockerfile" ]] && echo ".docker/php/Dockerfile" || echo ".docker/Dockerfile.php")
+          echo "DOCKERFILE=$DOCKERFILE" >> "$GITHUB_OUTPUT"
+
+      - name: Build container image
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          context: .docker/php
+          platforms: linux/amd64,linux/arm64
+          file: ${{ steps.dockerfile.outputs.DOCKERFILE }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Push container image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .docker/php
+          platforms: linux/amd64,linux/arm64
+          file: ${{ steps.dockerfile.outputs.DOCKERFILE }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Save Docker cache
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: php-buildx-${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,9 @@ services:
       - ./build_local:/var/www/html
 
   php:
-    build:
-      context: .docker/php
+    image: ghcr.io/librecodecoop/site-php:${PHP_IMAGE_TAG:-latest}
+    # build:
+    #   context: .docker/php
     ports:
       - "127.0.0.1:${HTTP_PORT_PHP:-3000}:3000"
       - "127.0.0.1:${HTTP_PORT_BROWSERSYNC:-3001}:3001"


### PR DESCRIPTION
Reason: build image locally could be very slow using old processors and also will consume a lot of storage.